### PR TITLE
Updating rexml and nori

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-24.04, windows-2019]
         ruby: ['3.0', '3.1']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, windows-2019]
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['3.0', '3.1']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'nori', '= 2.7.0' # nori 2.7.1 hasw a bug where it throws a NoMethodError for snakecase.
   s.add_runtime_dependency 'rexml', '~> 3.3' # needs to load at least 3.3.6 to get past a CVE
-  s.add_runtime_dependency 'rubygems', '>= 3.6'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'
   s.add_development_dependency 'rb-readline'

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -36,8 +36,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'gyoku', '~> 1.0'
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
-  s.add_runtime_dependency 'nori', '= 2.7.0' # nori 2.7.1 hasw a bug where it throws a NoMethodError for snakecase. 2.7.0 is the last known good version.
+  s.add_runtime_dependency 'nori', '= 2.7.0' # nori 2.7.1 hasw a bug where it throws a NoMethodError for snakecase.
   s.add_runtime_dependency 'rexml', '~> 3.3' # needs to load at least 3.3.6 to get past a CVE
+  s.add_runtime_dependency 'rubygems', '>= 3.6'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'
   s.add_development_dependency 'rb-readline'

--- a/winrm.gemspec
+++ b/winrm.gemspec
@@ -36,8 +36,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'gyoku', '~> 1.0'
   s.add_runtime_dependency 'httpclient', '~> 2.2', '>= 2.2.0.2'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
-  s.add_runtime_dependency 'nori', '~> 2.0'
-  s.add_runtime_dependency 'rexml', '~> 3.0'
+  s.add_runtime_dependency 'nori', '= 2.7.0' # nori 2.7.1 hasw a bug where it throws a NoMethodError for snakecase. 2.7.0 is the last known good version.
+  s.add_runtime_dependency 'rexml', '~> 3.3' # needs to load at least 3.3.6 to get past a CVE
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'
   s.add_development_dependency 'rb-readline'


### PR DESCRIPTION
Per Chef-16831, we're updating rexml to overcome CVE-2024-49761