### PR TITLE
Updating to overcome redefinition warnings

### DIFF
--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -40,6 +40,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "rexml", "~> 3.3" # needs to load at least 3.3.6 to get past a CVE
   s.add_development_dependency "pry"
   s.add_development_dependency "rake", ">= 10.3", "< 13"
+  s.add_development_dependency "ostruct"
+  s.add_development_dependency "fiddle"
+  s.add_development_dependency "benchmark"
   s.add_development_dependency "rb-readline"
   s.add_development_dependency "rspec", "~> 3.2"
   s.add_development_dependency "rubocop", "~> 1.25.1"

--- a/lib/chef-winrm/psrp/message_fragmenter.rb
+++ b/lib/chef-winrm/psrp/message_fragmenter.rb
@@ -26,7 +26,6 @@ module WinRM
         @max_blob_length = max_blob_length || DEFAULT_BLOB_LENGTH
       end
 
-      attr_reader :object_id
       attr_accessor :max_blob_length
 
       def fragment(message)
@@ -53,6 +52,10 @@ module WinRM
 
         fragment
       end
+
+      private
+
+      attr_reader :object_id
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In an update for chef-winrm-fs we noticed redefinition warnings coming from chef-winrm. To overcome those and prevent problems, we moved the offending attribute reader statement to a private block. 

We also were getting ruby warnings about gems being moved from the base ruby libraries so we're adding them here for posterity.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
