### PR TITLE
Correcting Redefinition warnings

### DIFF
--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = "chef-winrm"
   s.version = WinRM::VERSION
-  s.date = Date.today.to_s
 
   s.author = ["Dan Wanek", "Paul Morton", "Matt Wrock", "Shawn Neal"]
   s.email = [
@@ -30,14 +29,14 @@ Gem::Specification.new do |s|
   s.bindir = "bin"
   s.executables = ["rwinrm"]
   s.required_ruby_version = ">= 3.1"
-  s.add_runtime_dependency "builder", ">= 2.1.2"
-  s.add_runtime_dependency "chef-gyoku", ">= 1.5.0"
-  s.add_runtime_dependency "erubi", "~> 1.8"
-  s.add_runtime_dependency "gssapi", "~> 1.2"
-  s.add_runtime_dependency "httpclient", "~> 2.2", ">= 2.2.0.2"
-  s.add_runtime_dependency "logging", [">= 1.6.1", "< 3.0"]
-  s.add_runtime_dependency "nori", "= 2.7.0" # nori 2.7.1 has a bug where it throws a NoMethodError for snakecase.
-  s.add_runtime_dependency "rexml", "~> 3.3" # needs to load at least 3.3.6 to get past a CVE
+  s.add_dependency "builder", ">= 2.1.2"
+  s.add_dependency "chef-gyoku", ">= 1.5.0"
+  s.add_dependency "erubi", "~> 1.8"
+  s.add_dependency "gssapi", "~> 1.2"
+  s.add_dependency "httpclient", "~> 2.2", ">= 2.2.0.2"
+  s.add_dependency "logging", [">= 1.6.1", "< 3.0"]
+  s.add_dependency "nori", "= 2.7.0" # nori 2.7.1 has a bug where it throws a NoMethodError for snakecase.
+  s.add_dependency "rexml", "~> 3.3" # needs to load at least 3.3.6 to get past a CVE
   s.add_development_dependency "pry"
   s.add_development_dependency "rake", ">= 10.3", "< 13"
   s.add_development_dependency "ostruct"
@@ -46,9 +45,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rb-readline"
   s.add_development_dependency "syslog"
   s.add_development_dependency "rspec", "~> 3.2"
-  s.add_development_dependency "rubocop", "~> 1.25.1"
-  s.add_development_dependency "cookstyle", ">= 7.32.8"
-  s.add_runtime_dependency "rubyntlm", "~> 0.6.0", ">= 0.6.3"
+  s.add_development_dependency "cookstyle", ">= 8.0.0"
+  s.add_dependency "rubyntlm", "~> 0.6.0", ">= 0.6.3"
 
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.executables = ["rwinrm"]
   s.required_ruby_version = ">= 3.1"
   s.add_dependency "builder", ">= 2.1.2"
-  s.add_dependency "chef-gyoku", ">= 1.5.0"
+  s.add_dependency "chef-gyoku", "~> 1.5"
   s.add_dependency "erubi", "~> 1.8"
   s.add_dependency "gssapi", "~> 1.2"
   s.add_dependency "httpclient", "~> 2.2", ">= 2.2.0.2"

--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.executables = ["rwinrm"]
   s.required_ruby_version = ">= 3.1"
   s.add_runtime_dependency "builder", ">= 2.1.2"
-  s.add_runtime_dependency "chef-gyoku", ">= 1.4.1"
+  s.add_runtime_dependency "chef-gyoku", ">= 1.5.0"
   s.add_runtime_dependency "erubi", "~> 1.8"
   s.add_runtime_dependency "gssapi", "~> 1.2"
   s.add_runtime_dependency "httpclient", "~> 2.2", ">= 2.2.0.2"
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fiddle"
   s.add_development_dependency "benchmark"
   s.add_development_dependency "rb-readline"
+  s.add_development_dependency "syslog"
   s.add_development_dependency "rspec", "~> 3.2"
   s.add_development_dependency "rubocop", "~> 1.25.1"
   s.add_development_dependency "cookstyle", ">= 7.32.8"

--- a/lib/chef-winrm/http/transport.rb
+++ b/lib/chef-winrm/http/transport.rb
@@ -171,7 +171,7 @@ module WinRM
         log_soap_message(message)
 
         hdr = {
-          "Content-Type" => "multipart/encrypted;"\
+          "Content-Type" => "multipart/encrypted;" \
             'protocol="application/HTTP-SPNEGO-session-encrypted";boundary="Encrypted Boundary"',
         }
 

--- a/lib/chef-winrm/http/transport_factory.rb
+++ b/lib/chef-winrm/http/transport_factory.rb
@@ -46,7 +46,7 @@ module WinRM
           HTTP::BasicAuthSSL.new(opts[:endpoint], opts[:user], opts[:password], opts)
         elsif opts[:client_cert]
           HTTP::ClientCertAuthSSL.new(opts[:endpoint], opts[:client_cert],
-                                      opts[:client_key], opts[:key_pass], opts)
+            opts[:client_key], opts[:key_pass], opts)
         else
           HTTP::HttpNegotiate.new(opts[:endpoint], opts[:user], opts[:password], opts)
         end

--- a/lib/chef-winrm/psrp/fragment.rb
+++ b/lib/chef-winrm/psrp/fragment.rb
@@ -18,28 +18,30 @@ module WinRM
   module PSRP
     # PowerShell Remoting Protocol message fragment.
     class Fragment
+
+      attr_reader :psrp_object_id, :fragment_id, :end_fragment, :start_fragment, :blob
+
       # Creates a new PSRP message fragment
-      # @param object_id [Integer] The id of the fragmented message.
+      # @param psrp_object_id [Integer] The id of the fragmented message.
       # @param blob [Array] Array of fragmented bytes.
       # @param fragment_id [Integer] The id of this fragment
       # @param start_fragment [Boolean] If the fragment is the first fragment
       # @param end_fragment [Boolean] If the fragment is the last fragment
-      def initialize(object_id, blob, fragment_id = 0, start_fragment = true, end_fragment = true)
-        @object_id = object_id
+      def initialize(psrp_object_id, blob, fragment_id = 0, start_fragment = true, end_fragment = true)
+        @psrp_object_id = psrp_object_id
         @blob = blob
         @fragment_id = fragment_id
         @start_fragment = start_fragment
         @end_fragment = end_fragment
       end
 
-      # attr_reader :object_id, :fragment_id, :end_fragment, :start_fragment, :blob
 
       # Returns the raw PSRP message bytes ready for transfer to Windows inside a
       # WinRM message.
       # @return [Array<Byte>] Unencoded raw byte array of the PSRP message.
       def bytes
         [
-          int64be(object_id),
+          int64be(psrp_object_id),
           int64be(fragment_id),
           end_start_fragment,
           int16be(blob.length),

--- a/lib/chef-winrm/psrp/fragment.rb
+++ b/lib/chef-winrm/psrp/fragment.rb
@@ -32,7 +32,7 @@ module WinRM
         @end_fragment = end_fragment
       end
 
-      attr_reader :object_id, :fragment_id, :end_fragment, :start_fragment, :blob
+      # attr_reader :object_id, :fragment_id, :end_fragment, :start_fragment, :blob
 
       # Returns the raw PSRP message bytes ready for transfer to Windows inside a
       # WinRM message.

--- a/lib/chef-winrm/psrp/fragment.rb
+++ b/lib/chef-winrm/psrp/fragment.rb
@@ -35,7 +35,6 @@ module WinRM
         @end_fragment = end_fragment
       end
 
-
       # Returns the raw PSRP message bytes ready for transfer to Windows inside a
       # WinRM message.
       # @return [Array<Byte>] Unencoded raw byte array of the PSRP message.

--- a/lib/chef-winrm/psrp/message_data/error_record.rb
+++ b/lib/chef-winrm/psrp/message_data/error_record.rb
@@ -57,7 +57,7 @@ module WinRM
         end
 
         def underscore(camel)
-          camel.gsub(/::/, "/")
+          camel.gsub("::", "/")
             .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
             .gsub(/([a-z\d])([A-Z])/, '\1_\2')
             .tr("-", "_").downcase

--- a/lib/chef-winrm/psrp/message_defragmenter.rb
+++ b/lib/chef-winrm/psrp/message_defragmenter.rb
@@ -26,13 +26,13 @@ module WinRM
       def defragment(base64_bytes)
         fragment = fragment_from(Base64.decode64(base64_bytes))
 
-        @messages[fragment.object_id] ||= []
-        @messages[fragment.object_id].push fragment
+        @messages[fragment.psrp_object_id] ||= []
+        @messages[fragment.psrp_object_id].push fragment
 
         # rubocop:disable Style/GuardClause
         if fragment.end_fragment
           blob = []
-          @messages.delete(fragment.object_id).each { |frag| blob += frag.blob }
+          @messages.delete(fragment.psrp_object_id).each { |frag| blob += frag.blob }
           message_from(blob.pack("C*"))
         end
         # rubocop:enable Style/GuardClause

--- a/lib/chef-winrm/version.rb
+++ b/lib/chef-winrm/version.rb
@@ -1,5 +1,5 @@
 # WinRM module
 module WinRM
   # The version of the WinRM library
-  VERSION = "2.4.0".freeze
+  VERSION = "2.4.1".freeze
 end

--- a/lib/chef-winrm/wsmv/base.rb
+++ b/lib/chef-winrm/wsmv/base.rb
@@ -14,7 +14,7 @@
 
 require "base64" unless defined?(Base64)
 require "builder"
-require "gyoku"
+require "chef-gyoku"
 require_relative "soap"
 require_relative "header"
 

--- a/lib/chef-winrm/wsmv/cleanup_command.rb
+++ b/lib/chef-winrm/wsmv/cleanup_command.rb
@@ -44,9 +44,9 @@ module WinRM
 
       def cleanup_header
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(@shell_uri),
-                      action_signal,
-                      selector_shell_id(@shell_id))
+          resource_uri_shell(@shell_uri),
+          action_signal,
+          selector_shell_id(@shell_id))
       end
 
       def cleanup_body

--- a/lib/chef-winrm/wsmv/close_shell.rb
+++ b/lib/chef-winrm/wsmv/close_shell.rb
@@ -40,9 +40,9 @@ module WinRM
 
       def close_header
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(@shell_uri),
-                      action_delete,
-                      selector_shell_id(@shell_id))
+          resource_uri_shell(@shell_uri),
+          action_delete,
+          selector_shell_id(@shell_id))
       end
     end
   end

--- a/lib/chef-winrm/wsmv/command.rb
+++ b/lib/chef-winrm/wsmv/command.rb
@@ -63,7 +63,7 @@ module WinRM
 
       def issue69_unescape_single_quotes(xml)
         escaped_cmd = %r{<#{NS_WIN_SHELL}:Command>(.+)<\/#{NS_WIN_SHELL}:Command>}m.match(xml)[1]
-        xml[escaped_cmd] = escaped_cmd.gsub(/&#39;/, "'")
+        xml[escaped_cmd] = escaped_cmd.gsub("&#39;", "'")
         xml
       end
 
@@ -75,10 +75,10 @@ module WinRM
 
       def command_headers
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(@shell_uri),
-                      action_command,
-                      command_header_opts,
-                      selector_shell_id(@shell_id))
+          resource_uri_shell(@shell_uri),
+          action_command,
+          command_header_opts,
+          selector_shell_id(@shell_id))
       end
 
       def command_header_opts

--- a/lib/chef-winrm/wsmv/command_output.rb
+++ b/lib/chef-winrm/wsmv/command_output.rb
@@ -43,10 +43,10 @@ module WinRM
 
       def output_header
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(@shell_uri),
-                      action_receive,
-                      header_opts,
-                      selector_shell_id(@shell_id))
+          resource_uri_shell(@shell_uri),
+          action_receive,
+          header_opts,
+          selector_shell_id(@shell_id))
       end
 
       def header_opts

--- a/lib/chef-winrm/wsmv/configuration.rb
+++ b/lib/chef-winrm/wsmv/configuration.rb
@@ -36,8 +36,8 @@ module WinRM
 
       def configuration_headers
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell("http://schemas.microsoft.com/wbem/wsman/1/config"),
-                      action_get)
+          resource_uri_shell("http://schemas.microsoft.com/wbem/wsman/1/config"),
+          action_get)
       end
     end
   end

--- a/lib/chef-winrm/wsmv/create_pipeline.rb
+++ b/lib/chef-winrm/wsmv/create_pipeline.rb
@@ -51,9 +51,9 @@ module WinRM
 
       def command_headers
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(RESOURCE_URI_POWERSHELL),
-                      action_command,
-                      selector_shell_id(shell_id))
+          resource_uri_shell(RESOURCE_URI_POWERSHELL),
+          action_command,
+          selector_shell_id(shell_id))
       end
 
       def arguments

--- a/lib/chef-winrm/wsmv/create_shell.rb
+++ b/lib/chef-winrm/wsmv/create_shell.rb
@@ -83,9 +83,9 @@ module WinRM
 
       def shell_headers
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(@shell_uri),
-                      action_create,
-                      header_opts)
+          resource_uri_shell(@shell_uri),
+          action_create,
+          header_opts)
       end
 
       def action_create

--- a/lib/chef-winrm/wsmv/init_runspace_pool.rb
+++ b/lib/chef-winrm/wsmv/init_runspace_pool.rb
@@ -57,9 +57,9 @@ module WinRM
 
       def shell_headers
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(RESOURCE_URI_POWERSHELL),
-                      action_create,
-                      header_opts)
+          resource_uri_shell(RESOURCE_URI_POWERSHELL),
+          action_create,
+          header_opts)
       end
 
       def action_create

--- a/lib/chef-winrm/wsmv/keep_alive.rb
+++ b/lib/chef-winrm/wsmv/keep_alive.rb
@@ -43,10 +43,10 @@ module WinRM
 
       def keep_alive_headers
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(RESOURCE_URI_POWERSHELL),
-                      action_receive,
-                      header_opts,
-                      selector_shell_id(shell_id))
+          resource_uri_shell(RESOURCE_URI_POWERSHELL),
+          action_receive,
+          header_opts,
+          selector_shell_id(shell_id))
       end
 
       def header_opts

--- a/lib/chef-winrm/wsmv/write_stdin.rb
+++ b/lib/chef-winrm/wsmv/write_stdin.rb
@@ -53,9 +53,9 @@ module WinRM
 
       def stdin_headers
         merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(@shell_uri),
-                      action_send,
-                      selector_shell_id(@shell_id))
+          resource_uri_shell(@shell_uri),
+          action_send,
+          selector_shell_id(@shell_id))
       end
 
       def action_send


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
There's a couple of things going on here. First, chef-winrm was throwing redefinition warnings when running under Ruby 3.4. The issue was that there was a local variable called "object_id". That variable is the same name as an object in the Ruby Object base class. So, there really was a potential for mayhem there. CoPilot suggested renaming things and that worked great. Second, we had to tighten up the version of Chef-Gyoku we were using as it incorporated some changes we needed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
