### PR TITLE
Object Redefinition Part 2

### DIFF
--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rb-readline"
   s.add_development_dependency "syslog"
   s.add_development_dependency "rspec", "~> 3.2"
-  s.add_development_dependency "cookstyle", ">= 8.0.0"
+  s.add_development_dependency "cookstyle", "~> 8.1"
   s.add_dependency "rubyntlm", "~> 0.6.0", ">= 0.6.3"
 
   s.metadata["rubygems_mfa_required"] = "true"

--- a/lib/chef-winrm/psrp/message_fragmenter.rb
+++ b/lib/chef-winrm/psrp/message_fragmenter.rb
@@ -22,14 +22,14 @@ module WinRM
       DEFAULT_BLOB_LENGTH = 32_768
 
       def initialize(max_blob_length = DEFAULT_BLOB_LENGTH)
-        @object_id = 0
+        @custom_object_id = 0
         @max_blob_length = max_blob_length || DEFAULT_BLOB_LENGTH
       end
 
       attr_accessor :max_blob_length
 
       def fragment(message)
-        @object_id += 1
+        @custom_object_id += 1
         message_bytes = message.bytes
         bytes_fragmented = 0
         fragment_id = 0
@@ -39,7 +39,7 @@ module WinRM
           last_byte = bytes_fragmented + max_blob_length
           last_byte = message_bytes.length if last_byte > message_bytes.length
           fragment = Fragment.new(
-            object_id,
+            custom_object_id,
             message.bytes[bytes_fragmented..last_byte - 1],
             fragment_id,
             bytes_fragmented == 0,
@@ -55,7 +55,7 @@ module WinRM
 
       private
 
-      attr_reader :object_id
+      attr_reader :custom_object_id
     end
   end
 end

--- a/lib/chef-winrm/version.rb
+++ b/lib/chef-winrm/version.rb
@@ -1,5 +1,5 @@
 # WinRM module
 module WinRM
   # The version of the WinRM library
-  VERSION = "2.4.2".freeze
+  VERSION = "2.4.3".freeze
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This is the same problem as the previous PR. We missed this piece when updating that bit. the variable "object_id" matches an object in the base Ruby Object class and that could lead to mayhem. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
