### PR TITLE
CHEF-24484 skip user password for kerberos

### DIFF
--- a/lib/chef-winrm/connection_opts.rb
+++ b/lib/chef-winrm/connection_opts.rb
@@ -69,6 +69,9 @@ module WinRM
 
       if self[:client_cert]
         raise "path to client key is required" unless self[:client_key]
+      elsif self[:transport] == :kerberos
+        raise "realm is a required option" unless self[:realm]
+        raise "service is a required option" unless self[:service]
       else
         raise "user is a required option" unless self[:user]
         raise "password is a required option" unless self[:password]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

This pull request adds validation for required fields when using Kerberos transport in the `validate_required_fields` method of the `lib/chef-winrm/connection_opts.rb` file and there by skipping validations on user and password.


## Description
<!--- Describe your changes in detail, what problems does it solve? -->
* Added checks to ensure the `realm` and `service` options are provided when the `transport` is set to `:kerberos`. These fields are now mandatory for Kerberos authentication.
* Also skipped checks for user and password when the auth is kerberos implicitly.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
