### PR TITLE
Ensuring we are on rexml 3.4.2 or later for CVE-2025-58767

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -224,7 +224,7 @@ The repository uses the following GitHub labels:
 
 ### CI/CD Workflows
 - **Lint Workflow**: Runs cookstyle on all pull requests and main branch pushes
-- **Unit Test Workflow**: Runs unit tests on Windows 2019/2022 with Ruby 3.1/3.4
+- **Unit Test Workflow**: Runs unit tests on Windows 2022/2025 with Ruby 3.1/3.4
 
 ## Pull Request Creation Workflow
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
         ruby: ['3.1', '3.4']
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}

--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "httpclient", "~> 2.2", ">= 2.2.0.2"
   s.add_dependency "logging", [">= 1.6.1", "< 3.0"]
   s.add_dependency "nori", "= 2.7.0" # nori 2.7.1 has a bug where it throws a NoMethodError for snakecase.
-  s.add_dependency "rexml", "~> 3.3" # needs to load at least 3.3.6 to get past a CVE
+  s.add_dependency "rexml", "~> 3.4" # needs to load at least 3.4.2 to get past a CVE
   s.add_development_dependency "pry"
   s.add_development_dependency "rake", ">= 10.3", "< 13"
   s.add_development_dependency "ostruct"
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rb-readline"
   s.add_development_dependency "syslog"
   s.add_development_dependency "rspec", "~> 3.2"
-  s.add_development_dependency "cookstyle", "~> 8.1"
+  s.add_development_dependency "cookstyle", "~> 8.5"
   s.add_dependency "rubyntlm", "~> 0.6.0", ">= 0.6.3"
 
   s.metadata["rubygems_mfa_required"] = "true"

--- a/lib/chef-winrm/version.rb
+++ b/lib/chef-winrm/version.rb
@@ -1,5 +1,5 @@
 # WinRM module
 module WinRM
   # The version of the WinRM library
-  VERSION = "2.4.4".freeze
+  VERSION = "2.4.5".freeze
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
REXML has another CVE. We are updating it to at least version 3.4.2 or later.

## Related Issue
[CVE-2025-58767](https://progresssoftware.atlassian.net/browse/CHEF-26828)
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
