### PR TITLE
finalizer and rexml deprecation warning fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,13 +15,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.4
           bundler-cache: false
       - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
       - run: |
           gem install cookstyle
           cookstyle --chefstyle -c .rubocop.yml
-  

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,13 +47,13 @@ jobs:
       - name: Setup Machine
         run: |
           winrm.cmd quickconfig -q
-          net user /add vagrant vagrant
+          net user /add vagrant Pass@word1
           net localgroup administrators vagrant /add
           @"
           endpoint: "http://localhost:5985/wsman"
           user: vagrant
-          password: vagrant
+          password: Pass@word1
           "@ | Out-File -FilePath tests/integration/config.yml -Encoding utf8
 
-      - name: Verify Windows
+      - name: Run Integration Tests
         run: bundle exec rake integration

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,13 +11,12 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  unit-test:
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, windows-2022]
         ruby: ['3.1', '3.4']
-    name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     env:
       RUBYOPT: '--disable-error_highlight'
@@ -29,3 +28,32 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake spec
+
+  integration-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-2022]
+        ruby: ['3.1', '3.4']
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 600
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Setup Machine
+        run: |
+          winrm.cmd quickconfig -q
+          net user /add vagrant vagrant
+          net localgroup administrators vagrant /add
+          @"
+          endpoint: "http://localhost:5985/wsman"
+          user: vagrant
+          password: vagrant
+          "@ | Out-File -FilePath tests/integration/config.yml -Encoding utf8
+
+      - name: Verify Windows
+        run: bundle exec rake integration

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         ruby: ['3.1', '3.4']
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,4 +29,3 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake spec
-      - run: bundle exec rake integration

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Setup Machine
         run: |
           winrm.cmd quickconfig -q
+          winrm.cmd set winrm/config/service/auth '@{Basic="true"}'
+          winrm.cmd set winrm/config/service '@{AllowUnencrypted="true"}'
           net user /add vagrant Pass@word1
           net localgroup administrators vagrant /add
           @"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,17 +15,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, windows-2022]
         ruby: ['3.1', '3.4']
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     env:
       RUBYOPT: '--disable-error_highlight'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: ruby-setup
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake spec
+      - run: bundle exec rake integration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,5 +2,5 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "mwrock/WindowsNano"
+  config.vm.box = "stromweld/windows-11"
 end

--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "httpclient", "~> 2.2", ">= 2.2.0.2"
   s.add_dependency "logging", [">= 1.6.1", "< 3.0"]
   s.add_dependency "nori", "= 2.7.0" # nori 2.7.1 has a bug where it throws a NoMethodError for snakecase.
-  s.add_dependency "rexml", "~> 3.3" # needs to load at least 3.3.6 to get past a CVE
+  s.add_dependency "rexml", ">= 3.4.2", "< 4.0" # needs to load at least 3.4.2 for several CVE fixes
   s.add_development_dependency "pry"
   s.add_development_dependency "rake", ">= 10.3", "< 13"
   s.add_development_dependency "ostruct"

--- a/chef-winrm.gemspec
+++ b/chef-winrm.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gssapi", "~> 1.2"
   s.add_dependency "httpclient", "~> 2.2", ">= 2.2.0.2"
   s.add_dependency "logging", [">= 1.6.1", "< 3.0"]
-  s.add_dependency "nori", "= 2.7.0" # nori 2.7.1 has a bug where it throws a NoMethodError for snakecase.
+  s.add_dependency "nori", "~> 2.7"
   s.add_dependency "rexml", ">= 3.4.2", "< 4.0" # needs to load at least 3.4.2 for several CVE fixes
   s.add_development_dependency "pry"
   s.add_development_dependency "rake", ">= 10.3", "< 13"

--- a/lib/chef-winrm/http/response_handler.rb
+++ b/lib/chef-winrm/http/response_handler.rb
@@ -67,8 +67,8 @@ module WinRM
       return if soap_errors.empty?
 
       fault = REXML::XPath.first(
-        soap_errors,
-        "//*[local-name() = 'WSManFault']"
+        response_xml,
+        "//*[local-name() = 'Envelope']/*[local-name() = 'Body']/*[local-name() = 'Fault']/*[local-name() = 'Detail']//*[local-name() = 'WSManFault']"
       )
       raise WinRMWSManFault.new(fault.to_s, fault.attributes["Code"]) unless fault.nil?
     end
@@ -81,8 +81,8 @@ module WinRM
       return if soap_errors.empty?
 
       error = REXML::XPath.first(
-        soap_errors,
-        "//*[local-name() = 'MSFT_WmiError']"
+        response_xml,
+        "//*[local-name() = 'Envelope']/*[local-name() = 'Body']/*[local-name() = 'Fault']/*[local-name() = 'Detail']//*[local-name() = 'MSFT_WmiError']"
       )
       return if error.nil?
 
@@ -101,16 +101,16 @@ module WinRM
       return if soap_errors.empty?
 
       code = REXML::XPath.first(
-        soap_errors,
-        "//*[local-name() = 'Code']/*[local-name() = 'Value']/text()"
+        response_xml,
+        "//*[local-name() = 'Envelope']/*[local-name() = 'Body']/*[local-name() = 'Fault']/*[local-name() = 'Code']/*[local-name() = 'Value']/text()"
       )
       subcode = REXML::XPath.first(
-        soap_errors,
-        "//*[local-name() = 'Subcode']/*[local-name() = 'Value']/text()"
+        response_xml,
+        "//*[local-name() = 'Envelope']/*[local-name() = 'Body']/*[local-name() = 'Fault']/*[local-name() = 'Code']/*[local-name() = 'Subcode']/*[local-name() = 'Value']/text()"
       )
       reason = REXML::XPath.first(
-        soap_errors,
-        "//*[local-name() = 'Reason']/*[local-name() = 'Text']/text()"
+        response_xml,
+        "//*[local-name() = 'Envelope']/*[local-name() = 'Body']/*[local-name() = 'Fault']/*[local-name() = 'Reason']/*[local-name() = 'Text']/text()"
       )
 
       raise WinRMSoapFault.new(code, subcode, reason) unless

--- a/lib/chef-winrm/psrp/message_data/base.rb
+++ b/lib/chef-winrm/psrp/message_data/base.rb
@@ -35,7 +35,7 @@ module WinRM
             parser = Nori.new(
               parser: :rexml,
               advanced_typecasting: false,
-              convert_tags_to: ->(tag) { tag.snakecase.to_sym },
+              convert_tags_to: ->(tag) { tag.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase.to_sym },
               strip_namespaces: true
             )
             parser.parse(raw)[:obj][:ms]

--- a/lib/chef-winrm/shells/base.rb
+++ b/lib/chef-winrm/shells/base.rb
@@ -99,7 +99,7 @@ module WinRM
         # HTTP operations which need threads. Ruby 3.3+ doesn't allow thread
         # creation during finalization. The WinRM server will clean up
         # orphaned shells after the timeout period.
-        proc { }
+        proc {}
       end
 
       protected

--- a/lib/chef-winrm/shells/base.rb
+++ b/lib/chef-winrm/shells/base.rb
@@ -95,7 +95,7 @@ module WinRM
       end
 
       def self.finalize(connection_opts, transport, shell_id)
-        proc { Thread.new { close_shell(connection_opts, transport, shell_id) } }
+        proc { close_shell(connection_opts, transport, shell_id) }
       end
 
       protected

--- a/lib/chef-winrm/shells/base.rb
+++ b/lib/chef-winrm/shells/base.rb
@@ -95,7 +95,11 @@ module WinRM
       end
 
       def self.finalize(connection_opts, transport, shell_id)
-        proc { close_shell(connection_opts, transport, shell_id) }
+        # Don't attempt to close shell during finalization as it requires
+        # HTTP operations which need threads. Ruby 3.3+ doesn't allow thread
+        # creation during finalization. The WinRM server will clean up
+        # orphaned shells after the timeout period.
+        proc { }
       end
 
       protected

--- a/lib/chef-winrm/wsmv/wql_pull.rb
+++ b/lib/chef-winrm/wsmv/wql_pull.rb
@@ -15,7 +15,7 @@ module WinRM
         parser = Nori.new(
           parser: :rexml,
           advanced_typecasting: false,
-          convert_tags_to: ->(tag) { Nori::StringUtils.snakecase(tag).to_sym },
+          convert_tags_to: ->(tag) { tag.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase.to_sym },
           strip_namespaces: true
         )
         parser.parse(response.to_s)[:envelope][:body]

--- a/lib/chef-winrm/wsmv/wql_query.rb
+++ b/lib/chef-winrm/wsmv/wql_query.rb
@@ -30,7 +30,7 @@ module WinRM
         parser = Nori.new(
           parser: :rexml,
           advanced_typecasting: false,
-          convert_tags_to: ->(tag) { Nori::StringUtils.snakecase(tag).to_sym },
+          convert_tags_to: ->(tag) { tag.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase.to_sym },
           strip_namespaces: true
         )
         @items = Hash.new { |h, k| h[k] = [] }


### PR DESCRIPTION
## Description

Rexml 3.4.2 addressed several CVEs. Bumping dep to minimum 3.4.2. 3.4.2 also deprecated passing an array to XPath.first, match, each methods. This fixes those deprecations and eliminates the warning messages when test-kitchen is running about the rexml deprecation.

ruby 3.x doesn't allow new threads during finalization. This fixes the warning with windows after test-kitchen run about finalizer error that confuses users.

Nori 2.7.0 removed snakecase method and 2.7.1 removed the monkey patch. This fix removes the use of snakecase method and allows the latest version of Nori to work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
